### PR TITLE
Fix desired capabilities

### DIFF
--- a/sample-code/examples/ruby/simple_test.rb
+++ b/sample-code/examples/ruby/simple_test.rb
@@ -37,6 +37,7 @@ desired_caps = {
   caps:       {
     platformName:  'iOS',
     versionNumber: '7.1',
+    deviceName:    'iPhone Simulator',
     app:           APP_PATH,
   },
   appium_lib: {


### PR DESCRIPTION
In simple_test.rb file, desired capabilities lacked a 'deviceName' attribution.
