### PR TITLE
Update AndroidTest.java

### DIFF
--- a/sample-code/examples/java/junit/src/test/java/com/saucelabs/appium/AndroidTest.java
+++ b/sample-code/examples/java/junit/src/test/java/com/saucelabs/appium/AndroidTest.java
@@ -32,7 +32,7 @@ public class AndroidTest {
         capabilities.setCapability("app", app.getAbsolutePath());
         capabilities.setCapability("appPackage", "com.example.android.apis");
         capabilities.setCapability("appActivity", ".ApiDemos");
-        driver = new AppiumDriver(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
+        driver = new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
     }
 
     @After


### PR DESCRIPTION
According to the changelog, Appium2.0 has changed the AppiumDriver as a abstract class. 
update driver = new AppiumDriver(new URL("http://127.0.0.1:4723/wd/hub"), capabilities) to 
driver = new AndroidDriver(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);