### PR TITLE
Fix the ios-webview.js test

### DIFF
--- a/sample-code/examples/node/ios-webview.js
+++ b/sample-code/examples/node/ios-webview.js
@@ -44,7 +44,7 @@ describe("ios webview", function () {
   it("should get the url", function () {
     return driver
       .elementByXPath('//UIATextField[@value=\'Enter URL\']')
-        .sendKeys('https://www.google.com')
+        .sendKeys('www.google.com')
       .elementByName('Go').click()
       .elementByClassName('UIAWebView').click() // dismissing keyboard
       .context('WEBVIEW')


### PR DESCRIPTION
It was broken because the test WebView app automatically adds
"http://" to the address bar when it is selected. The ios-webiew.js
test tried to type "http://www.google.com" into the address bar,
resulting in trying go to "http://http://www.google.com" which caused
the test to fail.

Fix:  Type "www.google.com" into the address bar instead of
"http://www.google.com"