### PR TITLE
Update package.json modules

### DIFF
--- a/sample-code/examples/node/package.json
+++ b/sample-code/examples/node/package.json
@@ -22,12 +22,12 @@
   },
   "homepage": "https://github.com/appium/sample-code",
   "devDependencies": {
-    "chai": "^1.10.0",
-    "chai-as-promised": "^4.1.1",
+    "chai": "^2.2.0",
+    "chai-as-promised": "^5.0.0",
     "colors": "^1.0.3",
-    "express": "^4.10.2",
-    "q": "^1.1.1",
-    "underscore": "^1.7.0",
+    "express": "^4.12.3",
+    "q": "^2.0.2",
+    "underscore": "^1.8.3",
     "wd": "^0.3.11"
   }
 }


### PR DESCRIPTION
package.json modules for node examples were out of date. tweaked to latest stable versions.