### PR TITLE
Update appium_lib version number in gemfile

### DIFF
--- a/sample-code/examples/ruby/Gemfile
+++ b/sample-code/examples/ruby/Gemfile
@@ -1,6 +1,6 @@
 source 'https://www.rubygems.org'
 
-gem 'appium_lib',         '~> 3.0.2'
+gem 'appium_lib',         '~> 6.0.0'
 gem 'rest-client',        '~> 1.6.7'
 gem 'rspec',              '~> 2.14.1'
 gem 'cucumber',           '~> 1.3.15'


### PR DESCRIPTION
Update appium_lib version number in gemfile to resolve https://discus…s.appium.io/t/unable-to-run-tests-from-command-line/2602

Updating the appium_lib version number from 3.0.2 to 6.0.0 allow cucumber_os tests to be run.