### PR TITLE
Remove duplicate on .jshintrc options

### DIFF
--- a/sample-code/examples/node/.jshintrc
+++ b/sample-code/examples/node/.jshintrc
@@ -6,7 +6,6 @@
   "trailing": true,
   "node": true,
   "eqeqeq": true,
-  "trailing": true,
   "expr": true,
   "white": true,
   "indent": 2,


### PR DESCRIPTION
Just small fix I saw. There is a duplicate on trailing.