### PR TITLE
Fixed path to test app in python samples

### DIFF
--- a/sample-code/examples/python/ios_simple.py
+++ b/sample-code/examples/python/ios_simple.py
@@ -11,10 +11,7 @@ class SimpleIOSTests(unittest.TestCase):
 
     def setUp(self):
         # set up appium
-        app = os.path.join(os.path.dirname(__file__),
-                           '../../apps/TestApp/build/release-iphonesimulator',
-                           'TestApp.app')
-        app = os.path.abspath(app)
+        app = os.path.abspath('../../apps/TestApp/build/release-iphonesimulator/TestApp.app')
         self.driver = webdriver.Remote(
             command_executor='http://127.0.0.1:4723/wd/hub',
             desired_capabilities={


### PR DESCRIPTION
- The path to the TestApp.app was previously derived by concatenating a ‘system path + name_of_the_app’. I suppose this might have been done since they had too many example apps in the directory.

- Removed that concatenation step.

- All we need is a direct path to the test app.