### PR TITLE
Added npm run script commands to execute node tests.

### DIFF
--- a/sample-code/examples/node/README.md
+++ b/sample-code/examples/node/README.md
@@ -1,12 +1,6 @@
 #Node.js samples
 
-## prerequisites
-
-Upgrade Mocha to the latest version:
-
-```
-npm install -g -f mocha
-```
+## Prerequisites
 
 Install local packages:
 
@@ -14,111 +8,75 @@ Install local packages:
 npm install
 ```
 
-### to run tests locally
+### To run tests using Sauce Labs cloud
+
+[Sign up here](https://saucelabs.com/signup/trial)
+
+Then when running the tests, add your Sauce Labs credentials as npm config parameters, example :
+
+```
+npm run ios-simple appium-sample-code:sauce=1 appium-sample-code:sauce_username=<SAUCE_USERNAME> appium-sample-code:sauce_access_key=<SAUCE_ACCESS_KEY>
+```
+
+Or set the config parameters directly in package.json :
+
+```
+// package.json
+
+...
+"config":{
+  sauce:"1",
+  sauce_username:"<SAUCE_USERNAME>",
+  sauce_access_key:"<SAUCE_ACCESS_KEY>"
+},
+...
+```
+
+If you also want to use Sauce Connect (secure tunelling):
+
+- [Read the doc here](https://saucelabs.com/docs/connect)
+- Install and start the Sauce Connect client
+
+
+### To run tests locally
 
 Install appium and start the appium server for your device, please refer to:
 
 - http://appium.io
 - https://github.com/appium/appium/blob/master/README.md
 
-### to run tests using Sauce Labs cloud
-
-[Sign up here](https://saucelabs.com/signup/trial)
-
-Configure your environment:
-
-```
-export SAUCE_USERNAME=<SAUCE_USERNAME>
-export SAUCE_ACCESS_KEY=<SAUCE_ACCESS_KEY>
-```
-
-If you also want to use Sauce Connect (secure tunelling):
-
-- [Read the doc here](https://saucelabs.com/docs/connect)
-- Install and start the Sauce Connect client 
-
-## running tests
+## Running tests
 
 ###iOS
 
-####local:
-
 ```
-mocha ios-simple.js
-mocha ios-complex.js
-mocha ios-webview.js
-mocha ios-actions.js
-mocha ios-local-server.js
-mocha ios-selenium-webdriver-bridge.js
-```
-
-####using Sauce Labs:
-
-```
-SAUCE=1 mocha ios-simple.js
-SAUCE=1 mocha ios-complex.js
-SAUCE=1 mocha ios-webview.js
-SAUCE=1 mocha ios-actions.js
-SAUCE=1 mocha ios-selenium-webdriver-bridge.js
-```
-
-####using Sauce Labs + Sauce Connect:
-
-```
-SAUCE=1 mocha ios-local-server.js
+npm run ios-simple
+npm run ios-complex
+npm run ios-webview
+npm run ios-actions
+npm run ios-local-server
+npm run ios-selenium-webdriver-bridge
 ```
 
 ###Android
 
-####local:
-
 ```
-mocha android-simple.js
-mocha android-complex.js
-mocha android-webview.js
-mocha android-local-server.js
-```
-
-####using Sauce Labs:
-
-```
-SAUCE=1 mocha android-simple.js
-SAUCE=1 mocha android-complex.js
-SAUCE=1 mocha android-webview.js
-```
-
-####using Sauce Labs + Sauce Connect
-
-```
-SAUCE=1 mocha android-local-server.js
+npm run android-simple
+npm run android-complex
+npm run android-webview
+npm run android-local-server
 ```
 
 ###Selendroid
 
-####local:
-
 ```
-mocha selendroid-simple.js
-```
-
-####using Sauce Labs:
-
-```
-SAUCE=1 mocha selendroid-simple.js
+npm run selendroid-simple
 ```
 
 ###Node.js 0.11 + Generator with Yiewd
 
 prerequisite: switch to node > 0.11
 
-####local:
-
 ```
-mocha --harmony ios-yiewd.js
-```
-
-####using Sauce Labs:
-
-```
-SAUCE=1 mocha --harmony ios-yiewd.js
+npm run ios-yiewd
 ```

--- a/sample-code/examples/node/android-complex.js
+++ b/sample-code/examples/node/android-complex.js
@@ -17,16 +17,16 @@ describe("android complex", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
-    var desired = process.env.SAUCE ?
+    var desired = process.env.npm_package_config_sauce ?
       _.clone(require("./helpers/caps").android18) :
       _.clone(require("./helpers/caps").android19);
     desired.app = require("./helpers/apps").androidApiDemos;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'android - complex';
       desired.tags = ['sample'];
     }
@@ -39,7 +39,7 @@ describe("android complex", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });
@@ -57,7 +57,7 @@ describe("android complex", function () {
       .elementsByXPath('//android.widget.TextView[contains(@text, "Animat")]')
         .then(_p.filterDisplayed).first()
       .then(function (el) {
-        if (!process.env.SAUCE) {
+        if (!process.env.npm_package_config_sauce) {
           return el.text().should.become('Animation');
         }
         }).elementByXPath('//android.widget.TextView[@text=\'App\']').click()

--- a/sample-code/examples/node/android-local-server.js
+++ b/sample-code/examples/node/android-local-server.js
@@ -14,16 +14,16 @@ describe("android local server", function () {
 
   before(function () {
     localServer.start();
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
-    var desired = process.env.SAUCE ?
+    var desired = process.env.npm_package_config_sauce ?
       _.clone(require("./helpers/caps").android18) :
       _.clone(require("./helpers/caps").android19);
     desired.app = require("./helpers/apps").androidApiDemosLocal;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'android - local server';
       desired.tags = ['sample'];
     }
@@ -35,7 +35,7 @@ describe("android local server", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/android-simple.js
+++ b/sample-code/examples/node/android-simple.js
@@ -12,16 +12,16 @@ describe("android simple", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
-    var desired = process.env.SAUCE ?
+    var desired = process.env.npm_package_config_sauce ?
       _.clone(require("./helpers/caps").android18) :
       _.clone(require("./helpers/caps").android19);
     desired.app = require("./helpers/apps").androidApiDemos;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'android - simple';
       desired.tags = ['sample'];
     }
@@ -34,7 +34,7 @@ describe("android simple", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/android-webview.js
+++ b/sample-code/examples/node/android-webview.js
@@ -12,16 +12,16 @@ describe("android webview", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
-    var desired = process.env.SAUCE ?
+    var desired = process.env.npm_package_config_sauce ?
       _.clone(require("./helpers/caps").android18) :
       _.clone(require("./helpers/caps").android19);
     desired.app = require("./helpers/apps").selendroidTestApp;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'android - webview';
       desired.tags = ['sample'];
     }
@@ -34,7 +34,7 @@ describe("android webview", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/helpers/appium-servers.js
+++ b/sample-code/examples/node/helpers/appium-servers.js
@@ -7,6 +7,6 @@ exports.local = {
 exports.sauce = {
   host: 'ondemand.saucelabs.com',
   port: 80,
-  username: process.env.SAUCE_USERNAME,
-  password: process.env.SAUCE_ACCESS_KEY
+  username: process.env.npm_package_config_username,
+  password: process.env.npm_package_config_key
 };

--- a/sample-code/examples/node/ios-actions.js
+++ b/sample-code/examples/node/ios-actions.js
@@ -21,14 +21,14 @@ describe("ios actions", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").ios81);
     desired.app = require("./helpers/apps").iosTestApp;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'ios - actions';
       desired.tags = ['sample'];
     }
@@ -39,7 +39,7 @@ describe("ios actions", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/ios-complex.js
+++ b/sample-code/examples/node/ios-complex.js
@@ -15,14 +15,14 @@ describe("ios complex", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").ios81);
     desired.app = require("./helpers/apps").iosUICatalogApp;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'ios - complex';
       desired.tags = ['sample'];
     }
@@ -33,7 +33,7 @@ describe("ios complex", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });
@@ -185,7 +185,7 @@ describe("ios complex", function () {
       .back();
   });
 
-  if (!process.env.SAUCE) {
+  if (!process.env.npm_package_config_sauce) {
     it("should retrieve the session list", function () {
       driver.sessions()
       .then(function (sessions) {

--- a/sample-code/examples/node/ios-local-server.js
+++ b/sample-code/examples/node/ios-local-server.js
@@ -14,14 +14,14 @@ describe("ios local server", function () {
 
   before(function () {
     localServer.start();
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").ios81);
     desired.app = require("./helpers/apps").iosWebviewAppLocal;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'ios - local server';
       desired.tags = ['sample'];
     }
@@ -33,7 +33,7 @@ describe("ios local server", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/ios-safari.js
+++ b/sample-code/examples/node/ios-safari.js
@@ -12,14 +12,14 @@ describe("ios safari", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").ios81);
     desired.browserName = 'safari';
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'ios - safari';
       desired.tags = ['sample'];
     }
@@ -30,7 +30,7 @@ describe("ios safari", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/ios-selenium-webdriver-bridge.js
+++ b/sample-code/examples/node/ios-selenium-webdriver-bridge.js
@@ -33,9 +33,9 @@ describe("ios selenium webdriver bridge", function () {
       caps.set(key, val);
     });
     caps.set('app', require("./helpers/apps").iosTestApp);
-    if (process.env.SAUCE) {
-      caps.set('username', process.env.SAUCE_USERNAME);
-      caps.set('accessKey', process.env.SAUCE_ACCESS_KEY);
+    if (process.env.npm_package_config_sauce) {
+      caps.set('username', process.env.npm_package_config_username);
+      caps.set('accessKey', process.env.npm_package_config_key);
       caps.set('name', 'ios - selenium-webdriver bridge');
       caps.set('tags', ['sample']);
       builder = new webdriver.Builder()
@@ -59,7 +59,7 @@ describe("ios selenium webdriver bridge", function () {
     return new Q(driver
       .quit())
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return wdDriver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/ios-simple.js
+++ b/sample-code/examples/node/ios-simple.js
@@ -13,14 +13,14 @@ describe("ios simple", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").ios92);
     desired.app = require("./helpers/apps").iosTestApp;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'ios - simple';
       desired.tags = ['sample'];
     }
@@ -31,7 +31,7 @@ describe("ios simple", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/ios-webview.js
+++ b/sample-code/examples/node/ios-webview.js
@@ -12,14 +12,14 @@ describe("ios webview", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").ios81);
     desired.app = require("./helpers/apps").iosWebviewApp;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'ios - webview';
       desired.tags = ['sample'];
     }
@@ -30,7 +30,7 @@ describe("ios webview", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });

--- a/sample-code/examples/node/ios-yiewd.js
+++ b/sample-code/examples/node/ios-yiewd.js
@@ -15,7 +15,7 @@ describe("ios yiewd", function () {
   var driver;
   var allPassed = true;
 
-  var serverConfig = process.env.SAUCE ?
+  var serverConfig = process.env.npm_package_config_sauce ?
     serverConfigs.sauce : serverConfigs.local;
   driver = wd.remote(serverConfig.host,serverConfig.port, 
     serverConfig.username, serverConfig.password);
@@ -25,7 +25,7 @@ describe("ios yiewd", function () {
     driver.run(function* () {      
       var desired = _.clone(require("./helpers/caps").ios81);
       desired.app = require("./helpers/apps").iosTestApp;
-      if (process.env.SAUCE) {
+      if (process.env.npm_package_config_sauce) {
         desired.name = 'ios - simple';
         desired.tags = ['sample'];
       }
@@ -39,7 +39,7 @@ describe("ios yiewd", function () {
       try {
         yield driver.quit();
       } catch (ign) {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           yield driver.sauceJobStatus(allPassed);
         }      
       }

--- a/sample-code/examples/node/package.json
+++ b/sample-code/examples/node/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "Appium Sample Code",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/sample-code.git"
@@ -26,8 +23,26 @@
     "chai-as-promised": "^5.0.0",
     "colors": "^1.0.3",
     "express": "^4.12.3",
+    "mocha": "^2.4.5",
     "q": "^2.0.2",
     "underscore": "^1.8.3",
     "wd": "^0.3.11"
+  },
+  "config": {
+    "sauce":""
+  },
+    "scripts": {
+    "ios-simple": "SAUCE=$npm_package_config_sauce mocha ios-simple.js",
+    "ios-complex": "SAUCE=$npm_package_config_sauce mocha ios-complex.js",
+    "ios-webview": "SAUCE=$npm_package_config_sauce mocha ios-webview.js",
+    "ios-actions": "SAUCE=$npm_package_config_sauce mocha ios-actions.js",
+    "ios-local-server": "SAUCE=$npm_package_config_sauce mocha ios-local-server.js",
+    "ios-selenium-webdriver-bridge": "SAUCE=$npm_package_config_sauce mocha ios-selenium-webdriver-bridge.js",
+    "ios-yiewd": "SAUCE=$npm_package_config_sauce mocha ios-yiewd.js",
+    "android-simple": "SAUCE=$npm_package_config_sauce mocha android-simple.js",
+    "android-complex": "SAUCE=$npm_package_config_sauce mocha android-complex.js",
+    "android-webview": "SAUCE=$npm_package_config_sauce mocha android-webview.js",
+    "android-actions": "SAUCE=$npm_package_config_sauce mocha android-actions.js",
+    "selendroid-simple": "SAUCE=$npm_package_config_sauce mocha selendroid-simple.js"
   }
 }

--- a/sample-code/examples/node/package.json
+++ b/sample-code/examples/node/package.json
@@ -28,21 +28,18 @@
     "underscore": "^1.8.3",
     "wd": "^0.3.11"
   },
-  "config": {
-    "sauce":""
-  },
     "scripts": {
-    "ios-simple": "SAUCE=$npm_package_config_sauce mocha ios-simple.js",
-    "ios-complex": "SAUCE=$npm_package_config_sauce mocha ios-complex.js",
-    "ios-webview": "SAUCE=$npm_package_config_sauce mocha ios-webview.js",
-    "ios-actions": "SAUCE=$npm_package_config_sauce mocha ios-actions.js",
-    "ios-local-server": "SAUCE=$npm_package_config_sauce mocha ios-local-server.js",
-    "ios-selenium-webdriver-bridge": "SAUCE=$npm_package_config_sauce mocha ios-selenium-webdriver-bridge.js",
-    "ios-yiewd": "SAUCE=$npm_package_config_sauce mocha ios-yiewd.js",
-    "android-simple": "SAUCE=$npm_package_config_sauce mocha android-simple.js",
-    "android-complex": "SAUCE=$npm_package_config_sauce mocha android-complex.js",
-    "android-webview": "SAUCE=$npm_package_config_sauce mocha android-webview.js",
-    "android-actions": "SAUCE=$npm_package_config_sauce mocha android-actions.js",
-    "selendroid-simple": "SAUCE=$npm_package_config_sauce mocha selendroid-simple.js"
+    "ios-simple": "mocha ios-simple.js",
+    "ios-complex": "mocha ios-complex.js",
+    "ios-webview": "mocha ios-webview.js",
+    "ios-actions": "mocha ios-actions.js",
+    "ios-local-server": "mocha ios-local-server.js",
+    "ios-selenium-webdriver-bridge": "mocha ios-selenium-webdriver-bridge.js",
+    "ios-yiewd": "mocha --harmony ios-yiewd.js",
+    "android-simple": "mocha android-simple.js",
+    "android-complex": "mocha android-complex.js",
+    "android-webview": "mocha android-webview.js",
+    "android-actions": "mocha android-actions.js",
+    "selendroid-simple": "mocha selendroid-simple.js"
   }
 }

--- a/sample-code/examples/node/selendroid-simple.js
+++ b/sample-code/examples/node/selendroid-simple.js
@@ -12,14 +12,14 @@ describe("selendroid simple", function () {
   var allPassed = true;
 
   before(function () {
-    var serverConfig = process.env.SAUCE ?
+    var serverConfig = process.env.npm_package_config_sauce ?
       serverConfigs.sauce : serverConfigs.local;
     driver = wd.promiseChainRemote(serverConfig);
     require("./helpers/logging").configure(driver);
 
     var desired = _.clone(require("./helpers/caps").selendroid16);
     desired.app = require("./helpers/apps").androidApiDemos;
-    if (process.env.SAUCE) {
+    if (process.env.npm_package_config_sauce) {
       desired.name = 'selendroid - simple';
       desired.tags = ['sample'];
     }
@@ -32,7 +32,7 @@ describe("selendroid simple", function () {
     return driver
       .quit()
       .finally(function () {
-        if (process.env.SAUCE) {
+        if (process.env.npm_package_config_sauce) {
           return driver.sauceJobStatus(allPassed);
         }
       });


### PR DESCRIPTION
Hello,

This pull request enable those who clone this repository to execute the node tests using the npm [run script](https://docs.npmjs.com/cli/run-script) commands. It also changes the way to define Sauce Labs credentials by defining them as npm [config parameters](https://docs.npmjs.com/misc/config).

This has 2 advantages :

- Users do not have to install mocha globally to run the tests (or manually find the mocha executable in the node_modules folder every time they want to run one, in case they decide to install it locally).

- Defining Sauce Labs credentials is not platform specific anymore (the README only specify how to set those credentials on *nix systems).

I have updated the README to reflect those changes.

If you have any questions, let me know.

Thanks you for the sample codes, by the way. They are a really great help for learning how to use appium !