### PR TITLE
set Sauce Lab credentials environment variables from npm config params

### DIFF
--- a/sample-code/examples/node/helpers/setup.js
+++ b/sample-code/examples/node/helpers/setup.js
@@ -7,4 +7,9 @@ chai.use(chaiAsPromised);
 var should = chai.should();
 chaiAsPromised.transferPromiseness = wd.transferPromiseness;
 
+if (process.env.npm_package_config_sauce) {
+  process.env.SAUCE_USERNAME = process.env.npm_package_config_sauce_username;
+  process.env.SAUCE_ACCESS_KEY = process.env.npm_package_config_sauce_access_key;
+}
+
 exports.should = should;

--- a/sample-code/examples/node/ios-selenium-webdriver-bridge.js
+++ b/sample-code/examples/node/ios-selenium-webdriver-bridge.js
@@ -34,8 +34,8 @@ describe("ios selenium webdriver bridge", function () {
     });
     caps.set('app', require("./helpers/apps").iosTestApp);
     if (process.env.npm_package_config_sauce) {
-      caps.set('username', process.env.npm_package_config_username);
-      caps.set('accessKey', process.env.npm_package_config_key);
+      caps.set('username', process.env.npm_package_config_sauce_username);
+      caps.set('accessKey', process.env.npm_package_config_sauce_access_key);
       caps.set('name', 'ios - selenium-webdriver bridge');
       caps.set('tags', ['sample']);
       builder = new webdriver.Builder()


### PR DESCRIPTION
Hey guys,

Thank you for accepting my [pull request](https://github.com/appium/sample-code/pull/84) earlier ! 

However, since then, I learned that the Sauce Labs environment variables were [automatically picked up by WebDriver](https://www.npmjs.com/package/wd#environment-variables-for-saucelabs). Since my changes removed those variables, users will not be able to execute tests using Sauce Labs.

This pull requests fixes this issue by re-setting those environment variables from the npm config parameters.

Sorry about the bug I introduced, and thank you again for those great samples.
