### PR TITLE
Fixed path of the example app - UICatalog.app

### DIFF
--- a/sample-code/examples/python/ios_complex.py
+++ b/sample-code/examples/python/ios_complex.py
@@ -24,10 +24,7 @@ class ComplexIOSTests(unittest.TestCase):
         # set up appium
         # ** Important Note **
         # Make sure you have build the UICatalog applcation in your local repository
-        app = os.path.join(os.path.dirname(__file__),
-                           '../../apps/UICatalog/build/release-iphonesimulator',
-                           'UICatalog.app')
-        app = os.path.abspath(app)
+        app = os.path.abspath('../../apps/UICatalog/build/release-iphonesimulator/UICatalog.app')
         self.driver = webdriver.Remote(
             command_executor='http://127.0.0.1:4723/wd/hub',
             desired_capabilities={


### PR DESCRIPTION
Same as my previous pull request on ios_simple.py : #80

The path to the UICatalog.app was previously derived by concatenating a ‘system path' + 'name_of_the_app’. I suppose this might have been done since they had too many example apps in the directory.

Removed that concatenation step.

All we need is a direct path to the UICatalog app.