### PR TITLE
Updates tests for node: capabilities, url and npm args

### DIFF
--- a/sample-code/examples/node/README.md
+++ b/sample-code/examples/node/README.md
@@ -15,7 +15,8 @@ npm install
 Then when running the tests, add your Sauce Labs credentials as npm config parameters, example :
 
 ```
-npm run ios-simple appium-sample-code:sauce=1 appium-sample-code:sauce_username=<SAUCE_USERNAME> appium-sample-code:sauce_access_key=<SAUCE_ACCESS_KEY>
+npm run ios-simple --appium-sample-code:sauce=1 --appium-sample-code:username=<SAUCE_USERNAME> --appium-sample-code:key=<SAUCE_ACCESS_KEY>
+
 ```
 
 Or set the config parameters directly in package.json :

--- a/sample-code/examples/node/android-simple.js
+++ b/sample-code/examples/node/android-simple.js
@@ -1,8 +1,5 @@
 "use strict";
 
-console.log('process.env.npm_package_config_sauce');
-console.log(process.env.npm_package_config_sauce);
-
 require("./helpers/setup");
 
 var wd = require("wd"),

--- a/sample-code/examples/node/android-simple.js
+++ b/sample-code/examples/node/android-simple.js
@@ -1,5 +1,8 @@
 "use strict";
 
+console.log('process.env.npm_package_config_sauce');
+console.log(process.env.npm_package_config_sauce);
+
 require("./helpers/setup");
 
 var wd = require("wd"),

--- a/sample-code/examples/node/helpers/appium-servers.js
+++ b/sample-code/examples/node/helpers/appium-servers.js
@@ -7,6 +7,5 @@ exports.local = {
 exports.sauce = {
   host: 'ondemand.saucelabs.com',
   port: 80,
-  username: process.env.npm_package_config_username,
-  password: process.env.npm_package_config_key
+  auth: process.env.npm_package_config_username + ":" + process.env.npm_package_config_key
 };

--- a/sample-code/examples/node/helpers/caps.js
+++ b/sample-code/examples/node/helpers/caps.js
@@ -1,6 +1,6 @@
 exports.ios92 = {
   browserName: '',
-  'appium-version': '1.3',
+  appiumVersion: '1.5.3',
   platformName: 'iOS',
   platformVersion: '9.2',
   deviceName: 'iPhone 5s',
@@ -9,7 +9,7 @@ exports.ios92 = {
 
 exports.ios81 = {
   browserName: '',
-  'appium-version': '1.3',
+  appiumVersion: '1.5.3',
   platformName: 'iOS',
   platformVersion: '8.1',
   deviceName: 'iPhone Simulator',
@@ -18,27 +18,27 @@ exports.ios81 = {
 
 exports.android18 = {
   browserName: '',
-  'appium-version': '1.3',
+  appiumVersion: '1.5.3',
   platformName: 'Android',
-  platformVersion: '4.3',
+  platformVersion: '5.1',
   deviceName: 'Android Emulator',
   app: undefined // will be set later
 };
 
 exports.android19 = {
   browserName: '',
-  'appium-version': '1.3',
+  appiumVersion: '1.5.3',
   platformName: 'Android',
-  platformVersion: '4.4.2',
+  platformVersion: '5.1',
   deviceName: 'Android Emulator',
   app: undefined // will be set later
 };
 
 exports.selendroid16 = {
   browserName: '',
-  'appium-version': '1.3',
+  appiumVersion: '1.5.3',
   platformName: 'Android',
-  platformVersion: '4.1',
+  platformVersion: '5.1',
   automationName: 'selendroid',
   deviceName: 'Android Emulator',
   app: undefined // will be set later


### PR DESCRIPTION
This PR fixes issues I encountered when trying to run the sample tests:
- `url` no longer supports username and password, instead switched to `auth` string.
- Updated appium version and android version to versions available in Sauce labs. Gets a capability error otherwise.
- Updated README of npm args

Also rebased to use github email in author.