### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-#sample-code
+# sample-code
 
 This repository contains sample applications which are used mostly by appium functional tests.

--- a/sample-code/examples/dotnet/README.md
+++ b/sample-code/examples/dotnet/README.md
@@ -1,4 +1,4 @@
-#Appium DotNet samples
+# Appium DotNet samples
 
 ## Run locally
 

--- a/sample-code/examples/node/README.md
+++ b/sample-code/examples/node/README.md
@@ -1,4 +1,4 @@
-#Node.js samples
+# Node.js samples
 
 ## Prerequisites
 
@@ -48,7 +48,7 @@ Install appium and start the appium server for your device, please refer to:
 
 ## Running tests
 
-###iOS
+### iOS
 
 ```
 npm run ios-simple
@@ -59,7 +59,7 @@ npm run ios-local-server
 npm run ios-selenium-webdriver-bridge
 ```
 
-###Android
+### Android
 
 ```
 npm run android-simple
@@ -68,13 +68,13 @@ npm run android-webview
 npm run android-local-server
 ```
 
-###Selendroid
+### Selendroid
 
 ```
 npm run selendroid-simple
 ```
 
-###Node.js 0.11 + Generator with Yiewd
+### Node.js 0.11 + Generator with Yiewd
 
 prerequisite: switch to node > 0.11
 

--- a/sample-code/examples/python/pytest/README.md
+++ b/sample-code/examples/python/pytest/README.md
@@ -4,7 +4,7 @@ Python Pytest samples
 Tested on Python 3.5
 pip install -r requirements.txt
 
-#Run Syntax:
+# Run Syntax:
 py.test test_android_simple.py -v
 
 Output will be in the format:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
