### PR TITLE
Change all package.json files to have SPDX-compliant license values

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "testcode"
   ],
   "author": "appium",
-  "license": "apache-2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/appium/sample-code/issues"
   },

--- a/sample-code/examples/node/package.json
+++ b/sample-code/examples/node/package.json
@@ -13,7 +13,7 @@
     "examples"
   ],
   "author": "sebv",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/appium/sample-code/issues"
   },


### PR DESCRIPTION
`npm install` for this code complains about having a "valid SPDX license expression". Both package.json files specify the license should be Apache 2, but SPDX requires that it be written exactly as `Apache-2.0`. This PR updates both instances of package.json to comply.