### PR TITLE
Fix error with IOSDriver<MobileElement> declaration and avoid casting

### DIFF
--- a/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
+++ b/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
@@ -47,7 +47,7 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
 
     URL sauceUrl = new URL("http://" + authentication.getUsername() + ":"+ authentication.getAccessKey() + "@ondemand.saucelabs.com:80/wd/hub");
 
-    driver = new IOSDriver(sauceUrl, desiredCapabilities);
+    driver = new IOSDriver<MobileElement>(sauceUrl, desiredCapabilities);
     driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
     sessionId = driver.getSessionId().toString();
   }

--- a/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
+++ b/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
@@ -24,7 +24,7 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
   final private String ACCESS_KEY = System.getenv("SAUCE_ACCESS_KEY");
   private SauceOnDemandAuthentication authentication = new SauceOnDemandAuthentication(USERNAME, ACCESS_KEY);
 
-	private IOSDriver<MobileElement> driver;
+  private IOSDriver<MobileElement> driver;
   private String sessionId;
 
   @Rule
@@ -62,7 +62,7 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
   public void testUIComputation() {
 
     // populate text fields with values
-		MobileElement fieldOne = driver.findElementByAccessibilityId("TextField1");
+    MobileElement fieldOne = driver.findElementByAccessibilityId("TextField1");
     fieldOne.sendKeys("12");
 
     MobileElement fieldTwo = driver.findElementsByClassName("UIATextField").get(1);

--- a/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
+++ b/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
@@ -24,7 +24,7 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
   final private String ACCESS_KEY = System.getenv("SAUCE_ACCESS_KEY");
   private SauceOnDemandAuthentication authentication = new SauceOnDemandAuthentication(USERNAME, ACCESS_KEY);
 
-  private IOSDriver driver;
+	private IOSDriver<MobileElement> driver;
   private String sessionId;
 
   @Rule
@@ -62,10 +62,10 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
   public void testUIComputation() {
 
     // populate text fields with values
-    MobileElement fieldOne = (MobileElement) driver.findElementByAccessibilityId("TextField1");
+		MobileElement fieldOne = driver.findElementByAccessibilityId("TextField1");
     fieldOne.sendKeys("12");
 
-    MobileElement fieldTwo = (MobileElement) driver.findElementsByClassName("UIATextField").get(1);
+    MobileElement fieldTwo = driver.findElementsByClassName("UIATextField").get(1);
     fieldTwo.sendKeys("8");
 
     // they should be the same size, and the first should be above the second

--- a/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
+++ b/sample-code/examples/java/generic/src/test/java/SimpleIOSSauceTests.java
@@ -29,7 +29,7 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
 
   @Rule
   public SauceOnDemandTestWatcher resultReportingTestWatcher = new SauceOnDemandTestWatcher(this, authentication);
-  @Override
+
   public String getSessionId() {
     return sessionId;
   }
@@ -39,13 +39,13 @@ public class SimpleIOSSauceTests implements SauceOnDemandSessionIdProvider {
   @Before
   public void setUp() throws MalformedURLException {
     DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
-    desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, "7.1");
+    desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_NAME, "iOS");
+    desiredCapabilities.setCapability(MobileCapabilityType.PLATFORM_VERSION, "11.2");
     desiredCapabilities.setCapability(MobileCapabilityType.DEVICE_NAME, "iPhone Simulator");
     desiredCapabilities.setCapability(MobileCapabilityType.APP, "http://appium.s3.amazonaws.com/TestApp6.0.app.zip");
-    desiredCapabilities.setCapability("appiumVersion", "1.3.4");
     desiredCapabilities.setCapability("name", name.getMethodName());
 
-    URL sauceUrl = new URL("http://" + authentication.getUsername() + ":"+ authentication.getAccessKey() + "@ondemand.saucelabs.com:80/wd/hub");
+    URL sauceUrl = new URL("https://" + authentication.getUsername() + ":"+ authentication.getAccessKey() + "@ondemand.saucelabs.com:443/wd/hub");
 
     driver = new IOSDriver<MobileElement>(sauceUrl, desiredCapabilities);
     driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);


### PR DESCRIPTION
There is an error on line 79 that gives an error because List type is not known, so you can't getText().

You can either cast it to List<MobileElement>, or better yet, declare IOSDriver<MobileElement> on line 25 and then remove the unnecessary cast to (MobileElement on line 65 and line 68.