### PR TITLE
add a line for appium repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Refer https://github.com/appium/appium/tree/master/sample-code instead of this repository**
+
 # sample-code
 
 This repository contains sample applications which are used mostly by appium functional tests.


### PR DESCRIPTION
Our sample code has been moved to https://github.com/appium/appium/tree/master/sample-code , right?
To reduce new issue/comments for this repository, I'd put the reference in README