### PR TITLE
Change CalculatorResult.Text to pass the tests

### DIFF
--- a/sample-code/examples/C#/CalculatorTest/BasicScenarios.cs
+++ b/sample-code/examples/C#/CalculatorTest/BasicScenarios.cs
@@ -54,7 +54,7 @@ namespace CalculatorTest
             // TODO: Use a proper appium/webdriver nuget package that allow us to query based on automationId
             CalculatorSession.FindElementByXPath("//Button[@Name=\"Clear\"]").Click();
             CalculatorSession.FindElementByXPath("//Button[@Name=\"Seven\"]").Click();
-            CalculatorResult = CalculatorSession.FindElementByName("Display is  7 ") as RemoteWebElement;
+            CalculatorResult = CalculatorSession.FindElementByName("Display is 7") as RemoteWebElement;
             Assert.IsNotNull(CalculatorResult);
         }
 
@@ -74,7 +74,7 @@ namespace CalculatorTest
         public void Clear()
         {
             CalculatorSession.FindElementByName("Clear").Click();
-            Assert.AreEqual("Display is  0 ", CalculatorResult.Text);
+            Assert.AreEqual("Display is 0", CalculatorResult.Text);
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace CalculatorTest
             CalculatorSession.FindElementByName("Plus").Click();
             CalculatorSession.FindElementByName("Seven").Click();
             CalculatorSession.FindElementByName("Equals").Click();
-            Assert.AreEqual("Display is  8 ", CalculatorResult.Text);
+            Assert.AreEqual("Display is 8", CalculatorResult.Text);
         }
 
         [TestMethod]
@@ -99,7 +99,7 @@ namespace CalculatorTest
             CalculatorSession.FindElementByXPath("//Button[@Name=\"Divide by\"]").Click();
             CalculatorSession.FindElementByXPath("//Button[@Name=\"Eight\"]").Click();
             CalculatorSession.FindElementByXPath("//Button[@Name=\"Equals\"]").Click();
-            Assert.AreEqual("Display is  8 ", CalculatorResult.Text);
+            Assert.AreEqual("Display is 8", CalculatorResult.Text);
         }
 
         [TestMethod]
@@ -111,7 +111,7 @@ namespace CalculatorTest
             CalculatorSession.FindElementByName("One").Click();
             CalculatorSession.FindElementByName("One").Click();
             CalculatorSession.FindElementByName("Equals").Click();
-            Assert.AreEqual("Display is  8 ", CalculatorResult.Text);
+            Assert.AreEqual("Display is 8", CalculatorResult.Text);
         }
 
         [TestMethod]
@@ -121,7 +121,7 @@ namespace CalculatorTest
             CalculatorSession.FindElementByName("Multiply by").Click();
             CalculatorSession.FindElementByName("Nine").Click();
             CalculatorSession.FindElementByName("Equals").Click();
-            Assert.AreEqual("Display is  81 ", CalculatorResult.Text);
+            Assert.AreEqual("Display is 81", CalculatorResult.Text);
         }
 
         [TestMethod]
@@ -131,7 +131,7 @@ namespace CalculatorTest
             CalculatorSession.FindElementByName("Minus").Click();
             CalculatorSession.FindElementByName("One").Click();
             CalculatorSession.FindElementByName("Equals").Click();
-            Assert.AreEqual("Display is  8 ", CalculatorResult.Text);
+            Assert.AreEqual("Display is 8", CalculatorResult.Text);
         }
     }
 }


### PR DESCRIPTION
Original text caused the exception error indicating that the element could not be found in the page.